### PR TITLE
Fix compile error if SystemLinearizer was used with a Scalar other than double

### DIFF
--- a/ct_core/include/ct/core/systems/continuous_time/linear/SystemLinearizer.h
+++ b/ct_core/include/ct/core/systems/continuous_time/linear/SystemLinearizer.h
@@ -54,6 +54,8 @@ public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     typedef LinearSystem<STATE_DIM, CONTROL_DIM, SCALAR> Base;  //!< Base class type
+    
+    typedef typename Base::time_t time_t; //!< Time type as defined in System
 
     typedef typename Base::state_vector_t state_vector_t;                  //!< state vector type
     typedef typename Base::control_vector_t control_vector_t;              //!< input vector type

--- a/ct_core/include/ct/core/systems/continuous_time/linear/SystemLinearizer.h
+++ b/ct_core/include/ct/core/systems/continuous_time/linear/SystemLinearizer.h
@@ -134,7 +134,7 @@ public:
 	 */
     virtual const state_matrix_t& getDerivativeState(const state_vector_t& x,
         const control_vector_t& u,
-        const double t = 0.0) override
+        const time_t t = 0.0) override
     {
         dFdx_ = linearizer_.getDerivativeState(x, u, t);
 
@@ -164,7 +164,7 @@ public:
 	 */
     virtual const state_control_matrix_t& getDerivativeControl(const state_vector_t& x,
         const control_vector_t& u,
-        const double t = 0.0) override
+        const time_t t = 0.0) override
     {
         dFdu_ = linearizer_.getDerivativeControl(x, u, t);
 


### PR DESCRIPTION
In LinearSystem, the virtual methods getDerivativeControl and getDerivativeState are defined with time_t as their time parameter, which is a typedef for the template parameter SCALAR. The SystemLinearizer however uses a hardcoded double here. Thus, compilation fails if the class is instantiated with a different scalar type, as the override is no longer valid.