### PR TITLE
Resolve Memory Leaks in HPIPM Interface

### DIFF
--- a/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface-impl.hpp
+++ b/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface-impl.hpp
@@ -22,12 +22,26 @@ HPIPMInterface<STATE_DIM, CONTROL_DIM>::HPIPMInterface() : N_(-1), settings_(NLO
 template <int STATE_DIM, int CONTROL_DIM>
 HPIPMInterface<STATE_DIM, CONTROL_DIM>::~HPIPMInterface()
 {
-    // todo is there memory that needs to be freed?
+    if (dim_mem_) {
+        free(dim_mem_);
+        free(qp_mem_);
+        free(qp_sol_mem_);
+        free(ipm_arg_mem_);
+        free(ipm_mem_);
+    }
 }
 
 template <int STATE_DIM, int CONTROL_DIM>
 void HPIPMInterface<STATE_DIM, CONTROL_DIM>::initializeAndAllocate()
 {
+    if (dim_mem_) {
+        free(dim_mem_);
+        free(qp_mem_);
+        free(qp_sol_mem_);
+        free(ipm_arg_mem_);
+        free(ipm_mem_);
+    }
+    
     if (settings_.lqoc_solver_settings.lqoc_debug_print)
     {
         std::cout << "HPIPM allocating memory for QP with time horizon: " << N_ << std::endl;

--- a/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface-impl.hpp
+++ b/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface-impl.hpp
@@ -11,7 +11,8 @@ namespace ct {
 namespace optcon {
 
 template <int STATE_DIM, int CONTROL_DIM>
-HPIPMInterface<STATE_DIM, CONTROL_DIM>::HPIPMInterface() : N_(-1), settings_(NLOptConSettings())
+HPIPMInterface<STATE_DIM, CONTROL_DIM>::HPIPMInterface() : N_(-1), settings_(NLOptConSettings()), 
+    dim_mem_(nullptr), qp_mem_(nullptr), qp_sol_mem_(nullptr), ipm_arg_mem_(nullptr), ipm_mem_(nullptr)
 {
     hb0_.setZero();
     hr0_.setZero();
@@ -22,26 +23,14 @@ HPIPMInterface<STATE_DIM, CONTROL_DIM>::HPIPMInterface() : N_(-1), settings_(NLO
 template <int STATE_DIM, int CONTROL_DIM>
 HPIPMInterface<STATE_DIM, CONTROL_DIM>::~HPIPMInterface()
 {
-    if (dim_mem_) {
-        free(dim_mem_);
-        free(qp_mem_);
-        free(qp_sol_mem_);
-        free(ipm_arg_mem_);
-        free(ipm_mem_);
-    }
+    freeHpipmMemory();
 }
 
 template <int STATE_DIM, int CONTROL_DIM>
 void HPIPMInterface<STATE_DIM, CONTROL_DIM>::initializeAndAllocate()
 {
-    if (dim_mem_) {
-        free(dim_mem_);
-        free(qp_mem_);
-        free(qp_sol_mem_);
-        free(ipm_arg_mem_);
-        free(ipm_mem_);
-    }
-    
+    freeHpipmMemory();
+
     if (settings_.lqoc_solver_settings.lqoc_debug_print)
     {
         std::cout << "HPIPM allocating memory for QP with time horizon: " << N_ << std::endl;
@@ -94,6 +83,21 @@ void HPIPMInterface<STATE_DIM, CONTROL_DIM>::initializeAndAllocate()
         std::cout << "HPIPM ipm_arg_size: " << ipm_arg_size << std::endl;
         std::cout << "HPIPM ipm_size: " << ipm_size << std::endl;
     }
+}
+
+template <int STATE_DIM, int CONTROL_DIM>
+void HPIPMInterface<STATE_DIM, CONTROL_DIM>::freeHpipmMemory()
+{
+    free(dim_mem_);
+    free(qp_mem_);
+    free(qp_sol_mem_);
+    free(ipm_arg_mem_);
+    free(ipm_mem_);
+    dim_mem_ = nullptr;
+    qp_mem_ = nullptr;
+    qp_sol_mem_ = nullptr;
+    ipm_arg_mem_ = nullptr;
+    ipm_mem_ = nullptr;
 }
 
 

--- a/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface.hpp
+++ b/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface.hpp
@@ -165,6 +165,9 @@ private:
     //! prints the transposed of a matrix in column-major format, exp notation
     void d_print_e_tran_mat(int row, int col, double* A, int lda);
 
+    //! frees memory allocated for the HPIPM data structures
+    void freeHpipmMemory();
+
     //! horizon length
     int N_;
 
@@ -226,20 +229,20 @@ private:
 
     //! ocp qp dimensions
     int dim_size_;
-    void* dim_mem_{nullptr};
+    void* dim_mem_;
     struct d_ocp_qp_dim dim_;
 
-    void* qp_mem_{nullptr};
+    void* qp_mem_;
     struct d_ocp_qp qp_;
 
-    void* qp_sol_mem_{nullptr};
+    void* qp_sol_mem_;
     struct d_ocp_qp_sol qp_sol_;
 
-    void* ipm_arg_mem_{nullptr};
+    void* ipm_arg_mem_;
     struct d_ocp_qp_ipm_arg arg_;
 
     // workspace
-    void* ipm_mem_{nullptr};
+    void* ipm_mem_;
     struct d_ocp_qp_ipm_ws workspace_;
     int hpipm_status_;  // status code after solving
 

--- a/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface.hpp
+++ b/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface.hpp
@@ -226,20 +226,20 @@ private:
 
     //! ocp qp dimensions
     int dim_size_;
-    void* dim_mem_;
+    void* dim_mem_{nullptr};
     struct d_ocp_qp_dim dim_;
 
-    void* qp_mem_;
+    void* qp_mem_{nullptr};
     struct d_ocp_qp qp_;
 
-    void* qp_sol_mem_;
+    void* qp_sol_mem_{nullptr};
     struct d_ocp_qp_sol qp_sol_;
 
-    void* ipm_arg_mem_;
+    void* ipm_arg_mem_{nullptr};
     struct d_ocp_qp_ipm_arg arg_;
 
     // workspace
-    void* ipm_mem_;
+    void* ipm_mem_{nullptr};
     struct d_ocp_qp_ipm_ws workspace_;
     int hpipm_status_;  // status code after solving
 


### PR DESCRIPTION
Addresses issue https://github.com/ethz-adrl/control-toolbox/issues/88

Calling `HPIPMInterface::initializeAndAllocate()` now clears the memory allocated by previous calls to this function (e.g. when calling `HPIPMInterface::setProblemImpl()`).
The destructor of `HPIPMInterface` also clears these data structures now.