### PR TITLE
change include to use proper header file

### DIFF
--- a/ct/install_cppadcg.sh
+++ b/ct/install_cppadcg.sh
@@ -9,9 +9,9 @@ yes Y | sudo apt-get install llvm
 ## install CppAD
 mkdir /tmp/cppadcg_deps
 cd /tmp/cppadcg_deps
-wget https://github.com/coin-or/CppAD/archive/20190200.4.tar.gz
-tar -xzf 20190200.4.tar.gz
-cd CppAD-20190200.4
+wget https://github.com/coin-or/CppAD/archive/20200000.2.tar.gz
+tar -xzf 20200000.2.tar.gz
+cd CppAD-20200000.2
 mkdir build
 cd build
 cmake -Dcppad_prefix:PATH='/usr/local' ..
@@ -21,7 +21,7 @@ sudo make install
 ## install CppADCodeGen
 git clone https://github.com/joaoleal/CppADCodeGen.git /tmp/CppADCodeGen
 cd /tmp/CppADCodeGen
-git checkout 247e4bd74628fd4c20a6c0a7619413fa15e8b63c  ## commit matching Cppad 2019 version
+git checkout v2.4.2 ## commit matching Cppad 2020 version
 mkdir -p build
 cd build
 cmake .. #-DLLVM_VERSION=6.0

--- a/ct_core/include/ct/core/core.h
+++ b/ct_core/include/ct/core/core.h
@@ -19,7 +19,7 @@ Licensed under the BSD-2 license (see LICENSE file in main directory)
 #ifdef CPPAD
 #include <cppad/cppad.hpp>
 #include <cppad/example/cppad_eigen.hpp>
-#include <cppad/example/eigen_mat_inv.hpp>
+#include <cppad/example/atomic_two/eigen_mat_inv.hpp>
 #include "internal/autodiff/CppadParallel.h"
 #endif
 


### PR DESCRIPTION
Hello again, sorry for ghosting last time, a couple projects came up and yada yada yada.

Anyway here is a fix for https://github.com/ethz-adrl/control-toolbox/issues/70
CppAD just moved the file into their `atmoic_two` folder: https://github.com/coin-or/CppAD/blob/20200000.2/include/cppad/example/atomic_two/eigen_mat_inv.hpp

Also updated the `install_cppadcg.sh` file to make CI happy.