### PR TITLE
fix catching polymorphic type by value warning

### DIFF
--- a/ct_optcon/include/ct/optcon/costfunction/CostFunctionAD-impl.hpp
+++ b/ct_optcon/include/ct/optcon/costfunction/CostFunctionAD-impl.hpp
@@ -152,7 +152,7 @@ void CostFunctionAD<STATE_DIM, CONTROL_DIM, SCALAR>::loadFromConfigFile(const st
         try
         {
             termName = pt.get<std::string>(currentTerm + ".name");
-        } catch (boost::property_tree::ptree_bad_path err)
+        } catch (boost::property_tree::ptree_bad_path& err)
         {
             termName = "Unnamed";
             if (verbose)

--- a/ct_optcon/include/ct/optcon/costfunction/CostFunctionAnalytical-impl.hpp
+++ b/ct_optcon/include/ct/optcon/costfunction/CostFunctionAnalytical-impl.hpp
@@ -66,7 +66,7 @@ void CostFunctionAnalytical<STATE_DIM, CONTROL_DIM, SCALAR>::loadFromConfigFile(
             termName = pt.get<std::string>(currentTerm + ".name");
             if (verbose)
                 std::cout << "Trying to add " + termName + " as term" << std::endl;
-        } catch (boost::property_tree::ptree_bad_path err)
+        } catch (boost::property_tree::ptree_bad_path& err)
         {
             termName = "Unnamed";
             if (verbose)


### PR DESCRIPTION
ensures that the exception is passed by value, removes `polymorphic type by value` warning