### PR TITLE
Update cost in NLOC example

### DIFF
--- a/ct_optcon/examples/nlocCost.info
+++ b/ct_optcon/examples/nlocCost.info
@@ -9,13 +9,13 @@ intermediateCost
       Q
       {
         scaling 1.0
-        (0,0) 0
-        (1,1) 0.1
+        (0,0) 1
+        (1,1) 1
       }
       R
       {
-        scaling 1
-        (0,0) 1
+        scaling 0.001
+        (0,0) 0.1
       }
       x_des
       {
@@ -36,7 +36,7 @@ finalCost
     {
       Q
       {
-        scaling 100.0
+        scaling 1000.0
         (0,0) 1.0
         (1,1) 1.0
       }
@@ -46,7 +46,7 @@ finalCost
         (0,0) 0
       }
       x_des
-      {
+      {  
         (0,0) 1.5
         (1,0) 0
       }


### PR DESCRIPTION
My previous pull request breaks your NLOC example which might discourage the new users when they use those examples. So I updated the cost to let the example runs as expected.

The result from current cost parameters:

![Figure_1-1](https://user-images.githubusercontent.com/6488896/79993917-3153b700-84ad-11ea-9693-e4d339f4893f.png)

The result from updated cost parameters:
![Figure_1](https://user-images.githubusercontent.com/6488896/79994340-bd65de80-84ad-11ea-9034-a7ac8950ab83.png)
