### PR TITLE
remove optional numpy support to support a lower cmake version

### DIFF
--- a/ct/CMakeLists.txt
+++ b/ct/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.7)
+cmake_minimum_required(VERSION 3.12.4)
 project(ct VERSION 3.0.2 LANGUAGES CXX)
 
 #Make sure metapackage does not fail when building documentation

--- a/ct_core/CMakeLists.txt
+++ b/ct_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14.7)
+cmake_minimum_required (VERSION 3.12.4)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
@@ -63,7 +63,7 @@ else()
     message(STATUS "COMPILING WITHOUT QWT")
 endif()
 
-find_package(Python COMPONENTS Development NumPy QUIET)
+find_package(Python COMPONENTS Development QUIET)
 if (Python_FOUND AND ${Python_VERSION_MAJOR} EQUAL 3)
    message(STATUS "Found python " ${Python_VERSION})
    list(APPEND ct_core_COMPILE_DEFINITIONS PLOTTING_ENABLED)
@@ -87,7 +87,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ct/core/templateDir.h.in ${CM
 ## define the directories to be included in all ct_core targets
 list(APPEND ct_core_target_include_dirs ${EIGEN3_INCLUDE_DIR})
 list(APPEND ct_core_target_include_dirs ${Python_INCLUDE_DIRS})
-list(APPEND ct_core_target_include_dirs ${Python_NumPy_INCLUDE_DIRS})
 list(APPEND ct_core_target_include_dirs ${QWT_INCLUDE_DIR})
 list(APPEND ct_core_target_include_dirs $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 list(APPEND ct_core_target_include_dirs $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/examples/include>)

--- a/ct_doc/CMakeLists.txt
+++ b/ct_doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14.7)
+cmake_minimum_required (VERSION 3.12.4)
 
 project (ct_doc VERSION 3.0.2 )
 

--- a/ct_models/CMakeLists.txt
+++ b/ct_models/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14.7)
+cmake_minimum_required (VERSION 3.12.4)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)

--- a/ct_optcon/CMakeLists.txt
+++ b/ct_optcon/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14.7)
+cmake_minimum_required (VERSION 3.12.4)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)

--- a/ct_rbd/CMakeLists.txt
+++ b/ct_rbd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14.7)
+cmake_minimum_required (VERSION 3.12.4)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)


### PR DESCRIPTION
This PR address https://github.com/ethz-adrl/control-toolbox/pull/116#issuecomment-625800528

Basically more users can now use the cmake from their distribution, particularly the latest Debian 10 based distributions (which are a lot). Ubuntu 16 and 18 still have an older cmake, but we are still including the helper `install_cmake.sh` script so it should be fine. Since we are getting rid of the optional numpy dep, we can also probably go lower in the cmake version using `FindPythonLibs` instead of `FindPython` but do note `FindPythonLibs` is deprecated in 3.12 so I would not recommend that.

Tested with the `plotTest` script, get same behavior as before (i.e. still segfault on one of the tests, but the rest work)