### PR TITLE
remove unneeded computation

### DIFF
--- a/ct_optcon/include/ct/optcon/solver/lqp/GNRiccatiSolver-impl.hpp
+++ b/ct_optcon/include/ct/optcon/solver/lqp/GNRiccatiSolver-impl.hpp
@@ -157,8 +157,6 @@ void GNRiccatiSolver<STATE_DIM, CONTROL_DIM, SCALAR>::computeCostToGo(size_t k)
     sv_[k] = p.qv_[k];
     sv_[k].noalias() += p.A_[k].transpose() * sv_[k + 1];
     sv_[k].noalias() += p.A_[k].transpose() * S_[k + 1] * p.b_[k];
-    sv_[k].noalias() += this->L_[k].transpose() * Hi_[k] * this->lv_[k];
-    sv_[k].noalias() += this->L_[k].transpose() * gv_[k];
     sv_[k].noalias() += G_[k].transpose() * this->lv_[k];
 }
 


### PR DESCRIPTION
Was going through the math and I'm pretty sure L^T * gv + L^T * H * lv evaluates to zero in the computation for the value function first state derivative, sv.

L^T * gv + L^T * H * lv
= (- H^-1 * G)^T * gv + (- H^-1 * G)^T * H * (- H^-1 * gv)
= (- H^-1 * G)^T * gv + (H^-1 * G)^T * H * H^-1 * gv
= (-G^T * H^-T) * gv + (G^T * H^-T) H * H^-1 * gv
= (-G^T * H^-T) * gv + (G^T * H^-T) * gv
= 0

Edit: I have confirmed with `iLQRTest` and `ex_NLOC` that these modifications do not change the results.