### PR TITLE
fixed bug concerning hpipm_status display

### DIFF
--- a/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface-impl.hpp
+++ b/ct_optcon/include/ct/optcon/solver/lqp/HPIPMInterface-impl.hpp
@@ -198,7 +198,7 @@ void HPIPMInterface<STATE_DIM, CONTROL_DIM>::solve()
         {
             printf("\n -> Solver failed! Minimum step length reached\n");
         }
-        else if (hpipm_status_ == 2)
+        else if (hpipm_status_ == 3)
         {
             printf("\n -> Solver failed! NaN in computations\n");
         }


### PR DESCRIPTION
In the HPIPMInterface-impl.hpp, the return flag "hpipm_status==2" was considered twice. 