### PR TITLE
Easier integration into build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.5)
 
+project(ControlToolbox)
+
 add_subdirectory("ct_core/")
 add_subdirectory("ct_optcon/")
 add_subdirectory("ct_rbd/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required (VERSION 3.5)
+
+add_subdirectory("ct_core/")
+add_subdirectory("ct_optcon/")
+add_subdirectory("ct_rbd/")
+add_subdirectory("ct_models")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required (VERSION 3.5)
-
-project(ControlToolbox)
-
-add_subdirectory("ct_core/")
-add_subdirectory("ct_optcon/")
-add_subdirectory("ct_rbd/")
-add_subdirectory("ct_models")

--- a/ct_core/CMakeLists.txt
+++ b/ct_core/CMakeLists.txt
@@ -99,11 +99,13 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ct/core/templateDir.h.in ${CM
 
 ## define the directories to be included in all ct_core targets
 list(APPEND ct_core_target_include_dirs ${EIGEN3_INCLUDE_DIR})
-if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-    list(APPEND ct_core_target_include_dirs ${PYTHON_INCLUDE_DIRS})
-else()
-    list(APPEND ct_core_target_include_dirs ${Python_INCLUDE_DIRS})
-    list(APPEND ct_core_target_include_dirs ${Python_NumPy_INCLUDE_DIRS})
+if(${Python_FOUND})
+	if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+	    list(APPEND ct_core_target_include_dirs ${PYTHON_INCLUDE_DIRS})
+	else()
+	    list(APPEND ct_core_target_include_dirs ${Python_INCLUDE_DIRS})
+	    list(APPEND ct_core_target_include_dirs ${Python_NumPy_INCLUDE_DIRS})
+	endif()
 endif()
 list(APPEND ct_core_target_include_dirs ${QWT_INCLUDE_DIR})
 list(APPEND ct_core_target_include_dirs $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/ct_core/CMakeLists.txt
+++ b/ct_core/CMakeLists.txt
@@ -146,6 +146,7 @@ target_link_libraries(ct_core INTERFACE
     dl # required for gcc compatibility
     )
 
+set(ct_core ct_core CACHE INTERNAL "ct_core library target.")
 
 ##################
 # BUILD EXAMPLES #

--- a/ct_core/CMakeLists.txt
+++ b/ct_core/CMakeLists.txt
@@ -149,6 +149,7 @@ target_link_libraries(ct_core INTERFACE
     )
 
 set(ct_core ct_core CACHE INTERNAL "ct_core library target.")
+set(ct_plot ct_plot CACHE INTERNAL "ct_plot library target.")
 
 ##################
 # BUILD EXAMPLES #

--- a/ct_models/CMakeLists.txt
+++ b/ct_models/CMakeLists.txt
@@ -12,7 +12,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wfatal-errors -std=c++14 -Wall -Wno-unknown-pragmas")
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
-find_package(ct_rbd REQUIRED)
+if(NOT TARGET ${ct_rbd})
+	find_package(ct_rbd REQUIRED)
+endif()
 find_package(Boost REQUIRED system filesystem)
 
 # extract interface compile definitions from previous ct packages as options

--- a/ct_models/CMakeLists.txt
+++ b/ct_models/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required (VERSION 3.5)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/clang-cxx-dev-tools.cmake)
+if(NOT TARGET clang-format)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/clang-cxx-dev-tools.cmake)
+endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/ct-cmake-helpers.cmake)
 
 

--- a/ct_optcon/CMakeLists.txt
+++ b/ct_optcon/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required (VERSION 3.5)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/clang-cxx-dev-tools.cmake)
+if(NOT TARGET clang-format)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/clang-cxx-dev-tools.cmake)
+endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/ct-cmake-helpers.cmake)
 
 

--- a/ct_optcon/CMakeLists.txt
+++ b/ct_optcon/CMakeLists.txt
@@ -156,6 +156,7 @@ target_link_libraries(ct_optcon INTERFACE
     ${PRESPEC_LIB_NAMES}
     )
 
+set(ct_optcon ct_optcon CACHE INTERNAL "ct_optcon library target.")
 
 ##################
 # BUILD EXAMPLES #

--- a/ct_optcon/CMakeLists.txt
+++ b/ct_optcon/CMakeLists.txt
@@ -16,7 +16,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 
 ## find and include required dependencies
-find_package(ct_core REQUIRED)
+if(NOT TARGET ${ct_core})
+	find_package(ct_core REQUIRED)
+endif()
 # extract interface compile definitions from ct_core as options
 importInterfaceCompileDefinitionsAsOptions(ct_core)
 

--- a/ct_rbd/CMakeLists.txt
+++ b/ct_rbd/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required (VERSION 3.5)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/clang-cxx-dev-tools.cmake)
+if(NOT TARGET clang-format)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/compilerSettings.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/explicitTemplateHelpers.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/clang-cxx-dev-tools.cmake)
+endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/../ct/cmake/ct-cmake-helpers.cmake)
 
 project(ct_rbd VERSION 3.0.2 LANGUAGES CXX)

--- a/ct_rbd/CMakeLists.txt
+++ b/ct_rbd/CMakeLists.txt
@@ -13,7 +13,9 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wfatal-errors -std=c++14 -Wall -Wno-unk
 SET(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 find_package(kindr REQUIRED)
-find_package(ct_optcon REQUIRED)
+if(NOT TARGET ${ct_optcon})
+	find_package(ct_optcon REQUIRED)
+endif()
 
 # extract interface compile definitions from ct_core and ct_optcon as options
 importInterfaceCompileDefinitionsAsOptions(ct_core)

--- a/ct_rbd/CMakeLists.txt
+++ b/ct_rbd/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(ct_rbd INTERFACE)
 target_include_directories(ct_rbd INTERFACE ${ct_rbd_target_include_dirs})
 target_link_libraries(ct_rbd INTERFACE ct_optcon)
 
+set(ct_rbd ct_rbd CACHE INTERNAL "ct_rbd library target.")
 
 ###########
 # TESTING #


### PR DESCRIPTION
Hello,

I use CT as a backend for my helicopter path planner and struggled to integrate it into my existing build system. I encountered two problems with the existing install script: First of all, it automatically installs each module after building it so that interdependencies of consecutive modules can be resolved. This needs privileged access which is an annoyance when building my project. Second, without a top level CMakeLists.txt, you cannot simply add CT as an external project to your own project.
Since profound changes to this project are most likely rejected, I did the bare minimum to make CT work with my code. I added a root CMakeLists.txt so that it can be easily integrated as an external project. Since all modules are on the same hierarchy level, but have interdependencies, I had to cache the targets like 
`set(ct_core ct_core CACHE INTERNAL "ct_core library target.")`
This causes `ct_core` to be found by the other modules without the need of installing every single module.
Basically, that's it, but I encountered another problem when building CT on a linux machine without Python 3 libs installed. In ct_core/CMakeLists.txt, CMake tried to include Python headers even thou they have not been found, which is now being prevented. Your build script should still work fine btw. 
This is my second try on this problem and I hope that this solution is now acceptable for you.

Regards

Schulz0r