### PR TITLE
Using Python3.7

### DIFF
--- a/ct_core/src/core/plot/plot.cpp
+++ b/ct_core/src/core/plot/plot.cpp
@@ -59,7 +59,7 @@
                                  std::to_string(arg2) + ")");
 
 #ifdef PLOTTING_ENABLED
-#include <Python.h>
+#include <python3.7/Python.h>
 
 #define PyString_FromString PyUnicode_FromString
 #define PyInt_FromLong PyLong_FromLong


### PR DESCRIPTION
Hey, 

I'm using Ubuntu 18.04. I had a problem with the Python header file. When I tried to build it I had the compiler error. 

Therefore I tweaked it a little bit. It did not work for python2.7 though! Had an error with strings! I do not remember the exact details of the error. 

P.S.: sudo apt install libpython3.7-dev 

This PR maybe helpful! 
